### PR TITLE
feat: Implement Sales Data Import/Export

### DIFF
--- a/app/src/main/java/com/focusenterprise/data/SalesRecord.kt
+++ b/app/src/main/java/com/focusenterprise/data/SalesRecord.kt
@@ -128,13 +128,18 @@ data class SalesRecord(
 }
 
 /**
+ * Represents a detailed error for a specific row during import.
+ */
+data class RowError(val rowNumber: Int, val errorMessage: String)
+
+/**
  * Summary of sales import operation
  */
 data class SalesImportSummary(
     val totalRows: Int,
     val importedRows: Int,
     val skippedRows: Int,
-    val errors: List<String> = emptyList()
+    val errors: List<RowError> = emptyList()
 ) {
     val successRate: Double
         get() = if (totalRows > 0) (importedRows.toDouble() / totalRows) * 100 else 0.0


### PR DESCRIPTION
This commit introduces a robust and memory-efficient sales data import/export feature.

The export functionality has been refactored to use a streaming API (`SXSSFWorkbook`), which allows for exporting large datasets (10,000+ rows) without causing `OutOfMemoryError`.

The import functionality has been similarly refactored to use a SAX-based parser, which processes large Excel files row-by-row, also preventing memory issues.

The error handling for the import process has been significantly improved. The application now provides detailed, row-level error reporting in the UI and allows the user to download a full error report as a text file.

The progress indicator for the import process has been updated to an indeterminate circular progress bar with a row counter, providing better user feedback during the streaming import.